### PR TITLE
Fix news fetch server error

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -80,8 +80,12 @@ const App: React.FC = () => {
       if (shouldGenerateImage) {
         setLoadingMessage('Generating header image...');
         const imagePrompt = customImagePrompt.trim() || `A professional and visually appealing header image for a newsletter from ${companyName} about "${topics.join(', ')}". The style should be: ${visualKeywords}. Abstract and suitable for a ${industry} audience. Avoid text.`;
-        const imageBase64 = await generateHeaderImage(imagePrompt);
-        setHeaderImageUrl(`data:image/png;base64,${imageBase64}`);
+        try {
+          const dataUrl = await generateHeaderImage(imagePrompt);
+          setHeaderImageUrl(dataUrl);
+        } catch (e) {
+          console.warn('Header image failed, continuing without image.');
+        }
       }
 
     } catch (err) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,34 +17,78 @@ if (!apiKey) {
 
 const genai = apiKey ? new GoogleGenAI({ apiKey }) : null;
 
+// Fallback utilities
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+async function fetchGoogleNewsRss(topics: string[], minArticles: number) {
+  const results: { title: string; summary: string; source: string; link: string }[] = [];
+  const seen = new Set<string>();
+  for (const topic of topics) {
+    const q = encodeURIComponent(topic);
+    const url = `https://news.google.com/rss/search?q=${q}&hl=en-US&gl=US&ceid=US:en`;
+    try {
+      const r = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+      if (!r.ok) continue;
+      const xml = await r.text();
+      const items = xml.match(/<item>[\s\S]*?<\/item>/g) || [];
+      for (const item of items) {
+        const title = (item.match(/<title><!\[CDATA\[(.*?)\]\]><\/title>/)?.[1] || item.match(/<title>(.*?)<\/title>/)?.[1] || '').trim();
+        const link = (item.match(/<link>(.*?)<\/link>/)?.[1] || '').trim();
+        const source = (item.match(/<source[^>]*><!\[CDATA\[(.*?)\]\]><\/source>/)?.[1] || item.match(/<source[^>]*>(.*?)<\/source>/)?.[1] || 'Unknown').trim();
+        const description = (item.match(/<description>([\s\S]*?)<\/description>/)?.[1] || '').trim();
+        const summary = stripHtml(description).slice(0, 300);
+        if (title && link && !seen.has(link)) {
+          seen.add(link);
+          results.push({ title, summary, source, link });
+        }
+        if (results.length >= minArticles) break;
+      }
+    } catch {
+      // ignore
+    }
+    if (results.length >= minArticles) break;
+  }
+  return results;
+}
+
 app.get('/api/health', (_req, res) => {
   res.json({ ok: true, hasApiKey: Boolean(apiKey) });
 });
 
 app.post('/api/news', async (req, res) => {
   try {
-    if (!genai) return res.status(500).json({ error: 'Missing GEMINI_API_KEY' });
     const { topics, minArticles } = req.body as { topics: string[]; minArticles: number };
     if (!Array.isArray(topics) || !topics.length) return res.status(400).json({ error: 'topics required' });
     const min = typeof minArticles === 'number' && minArticles > 0 ? minArticles : 5;
 
-    const prompt = `Find the most recent (within the last 48 hours), top trending news articles for the following topics: ${topics.join(', ')}.
+    if (genai) {
+      try {
+        const prompt = `Find the most recent (within the last 48 hours), top trending news articles for the following topics: ${topics.join(', ')}.
 Focus on significant developments and announcements. For each article, find its title, a brief summary, the source website, and a direct link.
 Return at least ${min} diverse articles in total across all topics. Ensure the links are valid.
 Format the output as a valid JSON array of objects, where each object has keys: "title", "summary", "source", and "link".
 Do not include any introductory text, closing text, or markdown formatting like \`\`\`json. The entire response should be only the JSON array.`;
 
-    const response = await genai.models.generateContent({
-      model: 'gemini-2.5-flash',
-      contents: prompt,
-      config: { tools: [{ googleSearch: {} }] },
-    });
+        const response = await genai.models.generateContent({
+          model: 'gemini-2.5-flash',
+          contents: prompt,
+          config: { tools: [{ googleSearch: {} }] },
+        });
 
-    const rawText = response.text.trim();
-    const jsonText = rawText.replace(/^```json\n?/, '').replace(/\n?```$/, '');
-    const articles = JSON.parse(jsonText);
-    if (!Array.isArray(articles) || articles.length === 0) throw new Error('No articles returned');
-    res.json(articles);
+        const rawText = response.text.trim();
+        const jsonText = rawText.replace(/^```json\n?/, '').replace(/\n?```$/, '');
+        const articles = JSON.parse(jsonText);
+        if (Array.isArray(articles) && articles.length) return res.json(articles);
+      } catch (e) {
+        console.warn('AI news failed, using RSS fallback');
+      }
+    }
+
+    const rss = await fetchGoogleNewsRss(topics, min);
+    if (!rss.length) throw new Error('No articles available');
+    res.json(rss);
   } catch (err) {
     console.error('[/api/news] error', err);
     res.status(500).json({ error: 'Failed to fetch news' });
@@ -53,7 +97,6 @@ Do not include any introductory text, closing text, or markdown formatting like 
 
 app.post('/api/newsletter', async (req, res) => {
   try {
-    if (!genai) return res.status(500).json({ error: 'Missing GEMINI_API_KEY' });
     const { articles, options } = req.body as { articles: unknown; options: any };
     const { industry, companyName, tone, newsFormat, wordLength, additionalInstructions } = options || {};
     const articlesJson = JSON.stringify(articles, null, 2);
@@ -84,10 +127,27 @@ The audience is savvy and expects high-quality, relevant information.
 **News Articles Data:**
 ${articlesJson}`;
 
-    const response = await genai.models.generateContent({ model: 'gemini-2.5-flash', contents: prompt });
-    const newsletterHtml = response.text;
-    if (!newsletterHtml) throw new Error('Empty newsletter');
-    res.json({ html: newsletterHtml });
+    if (genai) {
+      const response = await genai.models.generateContent({ model: 'gemini-2.5-flash', contents: prompt });
+      const newsletterHtml = response.text;
+      if (!newsletterHtml) throw new Error('Empty newsletter');
+      return res.json({ html: newsletterHtml });
+    }
+
+    // Fallback deterministic HTML
+    const list = Array.isArray(articles) ? (articles as any[]) : [];
+    const sections = list.map((a) => {
+      const title = String(a.title || '').slice(0, 180);
+      const summary = String(a.summary || '').slice(0, 600);
+      const link = String(a.link || '#');
+      const source = String(a.source || 'Source');
+      return newsFormat === 'bullets'
+        ? `<section><h4>${title}</h4><ul><li>${summary}</li></ul><p><a href="${link}" target="_blank" rel="noopener noreferrer">${source}</a></p></section>`
+        : `<section><h4>${title}</h4><p>${summary}</p><p><a href="${link}" target="_blank" rel="noopener noreferrer">${source}</a></p></section>`;
+    }).join('\n');
+
+    const html = `<h1>${companyName} Weekly</h1>\n<h2>${industry} Highlights</h2>\n<p><em>Tone: ${tone}. ${additionalInstructions || ''}</em></p>\n<hr/>${sections}`;
+    res.json({ html });
   } catch (err) {
     console.error('[/api/newsletter] error', err);
     res.status(500).json({ error: 'Failed to generate newsletter' });
@@ -96,19 +156,25 @@ ${articlesJson}`;
 
 app.post('/api/image', async (req, res) => {
   try {
-    if (!genai) return res.status(500).json({ error: 'Missing GEMINI_API_KEY' });
     const { prompt } = req.body as { prompt: string };
     if (!prompt || typeof prompt !== 'string') return res.status(400).json({ error: 'prompt required' });
 
-    const response = await genai.models.generateImages({
-      model: 'imagen-4.0-generate-001',
-      prompt,
-      config: { numberOfImages: 1, outputMimeType: 'image/png', aspectRatio: '16:9' },
-    });
+    if (genai) {
+      const response = await genai.models.generateImages({
+        model: 'imagen-4.0-generate-001',
+        prompt,
+        config: { numberOfImages: 1, outputMimeType: 'image/png', aspectRatio: '16:9' },
+      });
 
-    if (!response.generatedImages || response.generatedImages.length === 0) throw new Error('No image');
-    const base64ImageBytes: string = response.generatedImages[0].image.imageBytes;
-    res.json({ imageBase64: base64ImageBytes });
+      if (!response.generatedImages || response.generatedImages.length === 0) throw new Error('No image');
+      const base64ImageBytes: string = response.generatedImages[0].image.imageBytes;
+      return res.json({ imageBase64: base64ImageBytes, mimeType: 'image/png' });
+    }
+
+    const title = (prompt || 'Newsletter').replace(/</g, '&lt;').replace(/>/g, '&gt;').slice(0, 140);
+    const svg = `<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0ea5e9"/><stop offset="100%" stop-color="#7c3aed"/></linearGradient></defs><rect width="1600" height="900" fill="url(#g)"/><g font-family="Verdana, DejaVu Sans, Arial" text-anchor="middle"><text x="800" y="470" font-size="72" fill="white" opacity="0.95">${title}</text></g></svg>`;
+    const base64 = Buffer.from(svg, 'utf8').toString('base64');
+    res.json({ imageBase64: base64, mimeType: 'image/svg+xml' });
   } catch (err) {
     console.error('[/api/image] error', err);
     res.status(500).json({ error: 'Failed to generate image' });
@@ -117,7 +183,6 @@ app.post('/api/image', async (req, res) => {
 
 app.post('/api/refine', async (req, res) => {
   try {
-    if (!genai) return res.status(500).json({ error: 'Missing GEMINI_API_KEY' });
     const { currentHtml, articles, refinementPrompt } = req.body as { currentHtml: string; articles: unknown; refinementPrompt: string };
     const prompt = `You are an AI assistant helping a user refine a newsletter. You will be given the current newsletter HTML, the original news articles it was based on, and a user's request for changes. Your task is to process the request and provide an updated newsletter.
 
@@ -140,11 +205,16 @@ ${JSON.stringify(articles, null, 2)}
     -   For all other requests, output ONLY the raw, updated HTML. Do not wrap it in markdown like \`\`\`html.
 
 Now, generate the response based on the user's request.`;
+    if (genai) {
+      const response = await genai.models.generateContent({ model: 'gemini-2.5-flash', contents: prompt });
+      const resultText = response.text.trim();
+      if (!resultText) throw new Error('Empty refinement');
+      return res.json({ result: resultText });
+    }
 
-    const response = await genai.models.generateContent({ model: 'gemini-2.5-flash', contents: prompt });
-    const resultText = response.text.trim();
-    if (!resultText) throw new Error('Empty refinement');
-    res.json({ result: resultText });
+    // Fallback: echo current HTML with a note about manual edits
+    const fallback = `${currentHtml}\n<!-- Refinement requested: ${refinementPrompt} (AI unavailable) -->`;
+    res.json({ result: fallback });
   } catch (err) {
     console.error('[/api/refine] error', err);
     res.status(500).json({ error: 'Failed to refine newsletter' });

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -40,7 +40,11 @@ export const generateHeaderImage = async (prompt: string): Promise<string> => {
   });
   if (!res.ok) throw new Error('Failed to generate header image');
   const data = await res.json();
-  return data.imageBase64 as string;
+  // If server returns PNG bytes, data:image prefix will be added by caller.
+  // If server returns SVG, caller can still use the same prefix with correct mime.
+  const mime: string = data.mimeType || 'image/png';
+  const base64: string = data.imageBase64 as string;
+  return `data:${mime};base64,${base64}`;
 };
 
 export const refineNewsletter = async (


### PR DESCRIPTION
Implement robust fallbacks for news, newsletter, and image generation to fix "Failed to fetch news from server" when the Gemini API key is missing.

When the Gemini API key is not configured or AI services fail, the server now fetches news from Google News RSS, generates a basic HTML newsletter, and provides a gradient SVG header image. The client also gracefully handles image generation failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-b62359e2-5074-4175-b445-5be5e9e74f45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b62359e2-5074-4175-b445-5be5e9e74f45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

